### PR TITLE
Vote for mayor now happens every 5 minutes

### DIFF
--- a/src/Components/Home.jsx
+++ b/src/Components/Home.jsx
@@ -1,19 +1,66 @@
-import React from 'react';
+import { React, useState, useEffect } from 'react';
 import 'bootstrap/dist/css/bootstrap.css'; // Import Bootstrap CSS
 import '../index.css';
+import axios from 'axios'
 
 import Footer from './footer';
 import NavBar from './NavBar';
 
+const getHomePageBanner = (mayor) => {
+    const mayorText = `Current Mayor: ${mayor.firstName} ${mayor.lastName}`
+    return (
+        <div>
+            <h1 className="display-4">Delegate</h1>
+            <p className="lead">{mayorText}</p>
+        </div>
+    )
+}
+
 function Home() {
+    const [mayor, setMayor] = useState({})
+    const [fetchMayor, setFetchMayor] = useState(true)
+    const [electMayor, setElectMayor] = useState(true)
+
+    useEffect(() => {
+        if(electMayor) {
+            try {
+                axios.post("http://localhost:9000/promoteMayor", {})
+                .then((res) => {
+                    if(res.data) {
+                        console.log(res.data)
+                        // Mayor is elected now fetch the mayor
+                        if(fetchMayor) {
+                            try {
+                                axios.get("http://localhost:9000/getMayorDetails", {})
+                                .then((res) => {
+                                    if(res.data) {
+                                        console.log(res.data)
+                                        setMayor(res.data)
+                                    }
+                                })
+                                setFetchMayor(false)
+                            }
+                            catch(err) {
+                                console.log(err)
+                            }
+                        }
+                    }
+                })
+            }
+            catch(err){
+                console.log(err)
+            }
+            setElectMayor(false)
+        }
+    })
+
     return (
         <div>
            <NavBar /> 
             <div className="container-fluid">
                 <img src="/images/bg.jpg" alt="banner" className="image"  />
                 <div className="jumbotron mt-2 custom-jumbotron text-center banner_content">
-                    <h1 className="display-4">Delegate!!!</h1>
-                    <p className="lead">Mayor Name</p>
+                    {getHomePageBanner(mayor)}
                 </div>
             
 

--- a/src/Components/NavBar.js
+++ b/src/Components/NavBar.js
@@ -53,6 +53,7 @@ const getRoleBasedActionsDropDown = () => {
                 <li><a class="dropdown-item" href="/viewLaws" >Vote Laws</a></li>
                 <li><a class="dropdown-item" href="/sendFeedback" >Feedback</a></li>
                 <li><a class="dropdown-item" href="/sendComplaint" >Complaint</a></li>
+                <li><a class="dropdown-item" href="/RegisterCandidate" >Register as Mayoral Candidate</a></li>
               </ul>
             </li>
     );

--- a/src/Components/VoteMayor.js
+++ b/src/Components/VoteMayor.js
@@ -60,15 +60,30 @@ function VoteMayor(props) {
       const cand = candidates.find((candidate) => candidate._id == selectedCandidate);
       alert(`You voted for Mayor : ${cand.firstName} ${cand.lastName}`);
       setVoted({ "id": user_id, "vote": selectedCandidate })
-      const votes = yesCount.find((vote) => vote.candidateId == cand._id);
-      let vote = votes.votes;
+      let votes = yesCount.find((vote) => vote.candidateId === cand._id);
+      let vote = 0;
+      if (votes == null) {
+        vote = 0;
+        votes = new Object({
+          candidateId: cand._id,
+          votes: 0,
+        })
+      }
+      else {
+        vote = votes.votes;
+      }
       vote = vote + 1;
       var index = yesCount.indexOf(votes);
       const updatedVote = new Object({
         candidateId: votes.candidateId,
         votes: vote,
       })
-      const yesses = [...yesCount]
+      let yesses = [...yesCount];
+      if (yesCount.length == 0) {
+        yesses = [vote];
+        index = 0;
+      }
+
       yesses[index] = updatedVote;
       const users = userID;
       users.push(user_id);

--- a/src/Server/Schema/MayorVotesSchema.jsx
+++ b/src/Server/Schema/MayorVotesSchema.jsx
@@ -9,6 +9,8 @@ const MayorVotesSchema = new mongoose.Schema({
     userID: [mongoose.Schema.Types.ObjectId],
     candidateID: [mongoose.Schema.Types.ObjectId],
     yesCount: [{ candidateId: mongoose.Schema.Types.ObjectId, votes: Number }],
+    startDate: Date,
+    endDate: Date,
 });
 
 const MayorVotes = mongoose.model("MayorVotes", MayorVotesSchema);


### PR DESCRIPTION
Every time the home page is loaded it makes an API call to /electMayor. Within elect mayor we check the new properties of mayorVote (startDate, endDate) to determine if the voting period has expired. If not, send a message to UI stating that the mayor's term has not expired yet. When the voting period has expired it checks to see if there are candidates registered within the mayorVote. If no candidates, just reelect the mayor, and extend the endDate's of both the mayor and the mayorVote by the term length (5mins for demo purposes) if there are candidates, find the one with the highest votes and save them. Next create the new Mayor entry in the Mayor table. Then update the isMayor property of the User's table for both the previous mayor and the new Mayor. Finally, delete all the candidates from the candidates table, delete the existing mayorVote, then create a blank mayorVote and return.

UI changes on the homepage to show the current mayor

Navbar changes that allow citizens to register as a mayoral candidate

logging errors on getMayorDetails endpoint for debugging